### PR TITLE
Simple config file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/*
+*.egg-info/
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 
 dependencies = [
   "numpy >= 1.18.5, < 2.0", 
-	"scipy <= 1.9.0", 
+	"scipy < 1.9.0", 
 	"scikit-learn", 
 	"persim", 
 	"ripser", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools"]  
+build-backend = "setuptools.build_meta" 
+
+[project]
+name = "fibered"
+version = "0.0.1"
+description = "Vector bundle learning algorithm for dimensionality reduction."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { file = "LICENSE" }
+authors = [
+  { name = "Luis Scoccola", email = "luis.scoccola@maths.ox.ac.uk" }
+]
+
+dependencies = [
+  "numpy >= 1.18.5, < 2.0", 
+	"scipy <= 1.9.0", 
+	"scikit-learn", 
+	"persim", 
+	"ripser", 
+	"python-flint",
+	"matplotlib", 
+	"plotly", 
+	"procrustes"
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools"]  
-build-backend = "setuptools.build_meta" 
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "fibered"
@@ -22,7 +22,7 @@ dependencies = [
 	"python-flint",
 	"matplotlib", 
 	"plotly", 
-	"procrustes"
+	"qc-procrustes"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This PR adds a simple [pyproject.toml](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/) file to root of the project, enabling the (optional) installation of the package files via pip, i.e.:

```bash
pip install ~/fibered
```

I've added what I believe are the working environment specs---scipy needs < 1.9.0 due to the deprecation of `linalg.pinv2`, which is used by the `qc-procrustes` package.

Any environment that previously worked with fibered will still work: all files and jupyter notebooks still do local (module) imports. This PR just adds an plain-text toml file (+ an gitignore file), incase someone wants to attempt to install via pip.

For reference, I was able to install via the following commands (from the project root): 

```bash
mamba create -n fibered python=3.9
mamba install "scipy < 1.9.0"
pip install .
```